### PR TITLE
Combined separate from datetime import lines

### DIFF
--- a/zkdashboard.py
+++ b/zkdashboard.py
@@ -4,9 +4,7 @@ import pathlib
 import re
 from collections import defaultdict
 import os
-from datetime import date
-from datetime import datetime
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 import random
 from dateutil.relativedelta import relativedelta
 import pyperclip


### PR DESCRIPTION
The three ```from datetime import``` lines at the beginning were combined following the scheme

```from X import Y```
```from X import Z```
can be rewritten as
```from X import Y, Z```